### PR TITLE
WIP: Fix for OBJ_find_sigid_algs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ LIBSODIUM_PREFIX=/usr/local
 make
 make check
 sudo checkinstall --strip=no --stripso=no --pkgname=libsodium-debug --provides=libsodium-debug --default
+export PKG_CONFIG_PATH="$LIBSODIUM_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
 ```
 
 ##### HACL

--- a/meths/ed25519_meth.c
+++ b/meths/ed25519_meth.c
@@ -101,7 +101,7 @@ static int ed25519_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                     EVP_MD_type((const EVP_MD *)p2));
 
             md_nid = EVP_MD_nid(p2);
-            if ( md_nid == NID_identity_md || md_nid == NID_sha512 ) {
+            if (md_nid == NID_identity_md) {
                 return 1;
             }
             errorf("%s: unsupported message digest '%s'\n", type_str, OBJ_nid2ln(md_nid));

--- a/meths/suola_asn1_meth.c
+++ b/meths/suola_asn1_meth.c
@@ -476,7 +476,7 @@ static int suola_ed25519_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *a
  * suola_register_asn1_meth(  NID_ED25519,
  *                            &ameth,
  *                            "ED25519",
- *                            "Ed25519 through libsodium");
+ *                            "ED25519");
  *
  * ameth is guaranteed to be non-NULL and unsupported nid are already filtered
  * out.

--- a/meths/suola_asn1_meth.h
+++ b/meths/suola_asn1_meth.h
@@ -29,7 +29,7 @@
  * suola_register_asn1_meth(  NID_ED25519,
  *                            &ameth,
  *                            "ED25519",
- *                            "Ed25519 through libsodium");
+ *                            "ED25519");
  */
 int suola_register_asn1_meth(int nid, EVP_PKEY_ASN1_METHOD **ameth, const char *pem_str, const char *info);
 

--- a/ossl/suola_objects_internal.h
+++ b/ossl/suola_objects_internal.h
@@ -28,10 +28,10 @@
 
 #define suola_OID_X25519   "1.3.101.110"
 #define suola_SN_X25519    "X25519"
-#define suola_LN_X25519    "EC DH X25519 through libsodium"
+#define suola_LN_X25519    "X25519"
 
 #define suola_OID_ED25519  "1.3.101.112"
 #define suola_SN_ED25519   "ED25519"
-#define suola_LN_ED25519   "Ed25519 through libsodium"
+#define suola_LN_ED25519   "ED25519"
 
 #endif /* SUOLA_OBJECTS_INTERNAL_H */

--- a/suola.c
+++ b/suola.c
@@ -291,16 +291,19 @@ static int suola_register_ameth(int id, EVP_PKEY_ASN1_METHOD **ameth, int flags)
         return 0;
 
     if (id == NID_X25519) {
-        pem_str = OBJ_nid2sn(id);
-        info = "EC DH X25519 through libsodium";
+        ;
     } else if (id == NID_ED25519) {
-        pem_str = OBJ_nid2sn(id);
-        info = "Ed25519 through libsodium";
+        if (!OBJ_add_sigid(NID_ED25519, NID_undef, NID_ED25519)) {
+            errorf("OBJ_add_sigid() failed\n");
+            return 0;
+        }
     } else {
         /* Unsupported method */
         return 0;
     }
 
+    pem_str = OBJ_nid2sn(id);
+    info = OBJ_nid2ln(id);
     return suola_register_asn1_meth(id, ameth, pem_str, info);
 }
 


### PR DESCRIPTION
Missing call to OBJ_add_sigid(NID_ED25519, NID_undef, NID_ED25519) to
register the combination if NID_undef (MD) & NID_ED25519 (PKEY) for
verifying certificates signed with the ED25519 OID